### PR TITLE
fix #2115: changing range into list in MultiPath class

### DIFF
--- a/nipype/interfaces/base.py
+++ b/nipype/interfaces/base.py
@@ -2072,7 +2072,10 @@ class MultiPath(traits.List):
                 isinstance(value, list) and
                 value and not
                 isinstance(value[0], list)):
-            newvalue = [value]
+            if isinstance(value, range):
+                newvalue = list(value)
+            else:
+                newvalue = [value]
         value = super(MultiPath, self).validate(object, name, newvalue)
 
         if len(value) > 0:

--- a/nipype/pipeline/engine/tests/test_engine.py
+++ b/nipype/pipeline/engine/tests/test_engine.py
@@ -456,6 +456,22 @@ def test_mapnode_iterfield_check():
     with pytest.raises(ValueError): mod1._check_iterfield()
 
 
+@pytest.mark.parametrize("x_inp, f_exp", [
+        (3, [9]), ([2, 3], [4, 9]), (range(3), [0, 1, 4])
+        ])
+def test_mapnode_iterfield_type(x_inp, f_exp):
+    from nipype import MapNode, Function
+    def square_func(x):
+        return x ** 2
+    square = Function(["x"], ["f_x"], square_func)
+
+    square_node = MapNode(square, name="square", iterfield=["x"])
+    square_node.inputs.x = x_inp
+
+    res  = square_node.run()
+    assert res.outputs.f_x == f_exp
+
+
 def test_mapnode_nested(tmpdir):
     os.chdir(str(tmpdir))
     from nipype import MapNode, Function


### PR DESCRIPTION
Checking if type of value is range (py3). If this is a case a simply change value to a list.

It fixes the problem in `MapNode`, now if `iterfield` is a range it is treated as a single element list - `[range()]`.